### PR TITLE
Fix Ruby version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -19,10 +19,9 @@ jobs:
     - name: Set up Ruby 2.6
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+    uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: '3.0.2'
 
     - name: Publish to GPR
       run: |


### PR DESCRIPTION
Update the Ruby version in the `.github/workflows/gem-push.yml` file to fix the setup issue.

* Change the `uses` line to `ruby/setup-ruby@v1` for automatic updates.
* Specify the Ruby version as `ruby-version: '3.0.2'` in the `Set up Ruby` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/friday_gemini_ai/pull/3?shareId=936fce16-abbb-4176-9545-da49ce6940e6).