### PR TITLE
Fix the workflow problem

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -15,12 +15,18 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       
+      - name: Install Bundler
+        run: gem install bundler
+
       - name: Set up Ruby 3.1.0
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.0'
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Publish to GPR
         run: |


### PR DESCRIPTION
Update the workflow configuration in `.github/workflows/gem-push.yml`.

* Change `actions/checkout` to use `v2` instead of `v4`.
* Add a step to install `bundler` before setting up Ruby.
* Add a step to install dependencies using `bundle install` before publishing.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/friday_gemini_ai/pull/4?shareId=1e5436b6-c558-4bed-9dff-334ea2066232).