### PR TITLE
Fix workflow to include tests and build verification

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Install dependencies
         run: bundle install
 
+      - name: Run tests
+        run: bundle exec rake test
+
+      - name: Verify build
+        run: gem build *.gemspec
+
       - name: Publish to GPR
         run: |
           mkdir -p $HOME/.gem


### PR DESCRIPTION
Add steps to run tests and verify build before publishing the gem in the workflow file.

* Add a step to run tests using `bundle exec rake test`.
* Add a step to verify the build using `gem build *.gemspec`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/friday_gemini_ai/pull/5?shareId=43130dfd-1069-4964-846e-ee7de1a92517).