### PR TITLE
Fix the workflow to include tests before publishing

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install Bundler
         run: gem install bundler --user-install
 
+      - name: Run Tests
+        run: bundle exec rake test
+
       - name: Publish to GPR
         run: |
           mkdir -p $HOME/.gem


### PR DESCRIPTION
Add a step to run tests before publishing the gem in the workflow file `.github/workflows/gem-push.yml`.

* Add a new step to run tests using `bundle exec rake test` after installing Bundler and before publishing the gem.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/friday_gemini_ai/pull/6?shareId=d23466d5-53db-4400-b80d-5cc30abb37c6).