### PR TITLE
Fix missing gems in GitHub Actions workflow

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Install Bundler
         run: gem install bundler --user-install
 
+      - name: Install Dependencies
+        run: |
+          gem install mini_mime
+          gem install multi_xml
+          gem install bigdecimal
+
       - name: Run Tests
         run: bundle exec rake test
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,7 @@ group :development, :test do
   gem 'rake', '~> 13.0'
   gem 'httparty', '~> 0.21.0'
   gem 'dotenv', '~> 2.8'
+  gem 'mini_mime', '~> 1.1.5'
+  gem 'multi_xml', '~> 0.7.1'
+  gem 'bigdecimal', '~> 3.1.9'
 end


### PR DESCRIPTION
Add missing gem dependencies to `Gemfile` and update GitHub Actions workflow to install them.

* **Gemfile**
  - Add `mini_mime` dependency
  - Add `multi_xml` dependency
  - Add `bigdecimal` dependency

* **.github/workflows/gem-push.yml**
  - Add step to install `mini_mime` gem
  - Add step to install `multi_xml` gem
  - Add step to install `bigdecimal` gem

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/friday_gemini_ai/pull/7?shareId=fb240258-a3dc-4352-b78e-fb7cf1587764).