### PR TITLE
Fix missing gems in workflow

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -26,10 +26,7 @@ jobs:
         run: gem install bundler --user-install
 
       - name: Install Dependencies
-        run: |
-          gem install mini_mime
-          gem install multi_xml
-          gem install bigdecimal
+        run: bundle install
 
       - name: Run Tests
         run: bundle exec rake test


### PR DESCRIPTION
Add `bundle install` step to the workflow file to ensure all required gems are installed before running tests.

* Remove individual gem installation commands.
* Add `bundle install` step to install all dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/friday_gemini_ai/pull/10?shareId=71818e66-7779-42e4-8f63-3e54a3242161).