### PR TITLE
Update Ruby version in workflow configuration

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Ruby 3.1.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.0'
+          ruby-version: '3.1.2'
 
       - name: Install Bundler
         run: gem install bundler --user-install


### PR DESCRIPTION
Update the Ruby version in the `.github/workflows/gem-push.yml` file to 3.1.2.

* Change the `ruby-version` key under the `Set up Ruby` step from '3.1.0' to '3.1.2'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/friday_gemini_ai/pull/11?shareId=57bf99ef-7e04-48d9-a880-9014a3c9a8fc).