### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment: production
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/11](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/11)

To resolve this issue, add an explicit `permissions` block to the `publish-rubygems` job in the workflow file. Since the job does not require repository write access (no actions that push or modify code, create releases, etc.), the minimal required permission is `contents: read`, which allows downloading artifacts and accessing repository content as needed. You should add the block just under the `runs-on` or `needs`/`environment` lines in the `publish-rubygems` job. No changes are required elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to explicitly request minimal repository read access during the RubyGems publish step, aligning with least-privilege best practices and improving CI reliability.
  * Clarifies permission scope for the publish job, reducing token exposure risk and ensuring compliant pipeline behavior.
  * No impact on application features or user workflows; no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->