### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 # This workflow requires GEMINI_API_KEY to be set as a repository secret


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/10](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/10)

To resolve the CodeQL-reported issue, set explicit permissions for the GITHUB_TOKEN in your workflow. Per GitHub's recommendations, add a top-level `permissions` block to the workflow YAML immediately beneath the `name:` field, unless a job requires elevated permissions. For this workflow, jobs primarily check out code, run Ruby scripts, and upload artifacts—none require write access to the repository. Therefore, the minimal recommended permissions are `contents: read`, which allows jobs to read repository content as needed for checking out code. If any job is later updated to perform pull request or issue modifications, elevate only those job's permissions accordingly. This edit should be made at the root level of `.github/workflows/ci.yml`, so all jobs inherit the restriction, by inserting:

```yaml
permissions:
  contents: read
```

immediately after `name: CI` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
