### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
     name: Build and Package
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
     outputs:
       gem-version: ${{ steps.gem-info.outputs.version }}
       gem-name: ${{ steps.gem-info.outputs.name }}


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/9](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/9)

To resolve this issue, add an explicit `permissions` block to the `build` job in `.github/workflows/release.yml` that limits the `GITHUB_TOKEN` scope to the least required privilege. For build jobs that do not need to write or modify repository contents, the best minimal permissions are `contents: read`. This change should be made within the `build:` job’s definition, immediately after its `runs-on` and `needs` directives, prior to its steps. No imports or external definitions are required; simply a single YAML configuration entry.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
