### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Security
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/8](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/8)

To fix this problem, explicitly add a `permissions` key limiting GITHUB_TOKEN exposure. The most effective way is to add `permissions: contents: read` at the top (root) of the workflow. This applies the least privilege necessary for the actions performed in this workflow, and individual jobs can always override this if more permissions are later required.  
Add the following lines just after the `name:` key (and before `on:`), i.e., after line 1.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
