### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     name: Pre-release Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/5](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/5)

To fix the problem, add an explicit `permissions` key to the `test` job (starting at line 9), specifying the minimal required permissions. In this case, the test job only needs to fetch repository contents to run tests, so `contents: read` is sufficient. No other permissions are required. You should add:

```yaml
permissions:
  contents: read
```

immediately after the job name (after line 10, or before/after `runs-on`, as the order is not strict). This ensures that the automatically generated `GITHUB_TOKEN` will not have write or other elevated permissions for this job.

No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
