### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,5 +1,10 @@
 name: Cleanup
 
+permissions:
+  issues: write
+  pull-requests: write
+  actions: write
+
 on:
   schedule:
     # Run monthly on the 1st at 3 AM UTC


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/4](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/4)

To address this issue, an explicit `permissions:` block should be added to the workflow. This restricts the `GITHUB_TOKEN` token permissions for the scope of the workflow (or jobs) to the minimal set required.

- The action `actions/stale` requires `issues: write` and `pull-requests: write` permissions to mark and close issues and PRs.
- The action `c-hive/gha-remove-artifacts` requires `actions: write` permission to delete artifacts.
- Therefore, add the following at the root of the workflow, to apply to all jobs:  
  ```yaml
  permissions:
    issues: write
    pull-requests: write
    actions: write
  ```
- This should be placed directly below the `name:` or `on:` keys, whichever is clearer (conventionally just after `name:` or just before `on:`).

No extra dependencies or configuration is needed. No changes are required to the jobs' internals, just the addition of this block at the workflow YAML root.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
