### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,3 +1,7 @@
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 name: Cleanup
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/3](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/3)

To address this problem, we should add an explicit `permissions` block to restrict the permissions allocated to the GITHUB_TOKEN. This block can be placed at either the workflow root (applies to all jobs) or per-job (for job-specific permissions). The actions in this workflow (closing stale issues/PRs, deleting artifacts) require `contents: write`, `issues: write`, and `pull-requests: write` as a minimal starting point.  
The best fix is to add a root-level `permissions` block immediately after the `name:` section, granting only the specific permissions needed by both jobs. This minimizes privilege and complies with CodeQL/industry best practices. No new dependencies, methods, or imports are needed. Only a single change is required within the existing `.github/workflows/cleanup.yml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
