### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   update-dependencies:
     name: Update Dependencies
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/2](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/2)

The workflow should explicitly set a `permissions` block. Since this workflow checks out code and then **creates a pull request** using the `peter-evans/create-pull-request@v5` action, it needs:
- `contents: write` (required to push branches/commits for PRs)
- `pull-requests: write` (to open PRs)

The `permissions` key can be added at the job level (inside `update-dependencies:`), instructing GitHub to grant only these privileges for this job, regardless of broader repository defaults. This change can be made directly under the job name (line 12), before the `runs-on` value. No other changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
