### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete regular expression for hostnames

### DIFF
--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -696,7 +696,7 @@ class TestClient < Minitest::Test
     GeminiAI::Client.stubs(:logger).returns(logger)
 
     # Setup the API response
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 200,
         body: @success_response.to_json,


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/22](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/22)

To fix the problem, the regular expression used in the `stub_request` call must be updated so that the dots (`.`) in the hostname are escaped (`\.`). This ensures that only the intended hostname `generativelanguage.googleapis.com` (and possible subpaths, not other similar hostnames) is matched.  

- **How**: Replace `/generativelanguage.googleapis.com/` with `/generativelanguage\.googleapis\.com/` so that the regex matches only the literal periods in the domain.
- **Files/lines**: In `test/unit/client_test.rb`, specifically at the line 699 within the `test_redacts_api_key_in_logs` method.
- **No additional imports or methods** are needed; just correct the regular expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined request stubbing in unit tests to ensure exact host matching, improving reliability of log redaction verification.
  * Enhances test determinism, reducing false positives and flakiness in CI pipelines.
  * No changes to production code or user-facing behavior; runtime functionality remains unchanged.
  * Strengthens coverage around sensitive data handling to better catch regressions early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->