### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/26](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/26)

The best fix is to add an explicit `permissions` block to the workflow or specifically to the `build` job, depending on desired granularity. Since multiple jobs in the workflow do not require write access (including, but not limited to, `build`), it's generally safest to set a restrictive default at the workflow root (just beneath `name: CI`), such as `permissions: contents: read`. Then, if an individual job (for example, `release`) requires broader permissions (e.g., `contents: write` to publish releases), it should set its own block. This approach enforces least privilege for all jobs by default.  

To fix, in `.github/workflows/ci.yml`, add:

- `permissions:` block with `contents: read` below the top-level `name: CI`.  
- If jobs require other permissions (not shown for the `build` job), they can override as needed.

No additional imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
