### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete regular expression for hostnames

### DIFF
--- a/test/integration/newmodels.rb
+++ b/test/integration/newmodels.rb
@@ -176,7 +176,7 @@ class TestNewModels < Minitest::Test
       # Create a unique response for each model
       response_text = "Response from model: #{model}"
 
-      stub_request(:post, /generativelanguage.googleapis.com/)
+      stub_request(:post, /generativelanguage\.googleapis\.com/)
         .to_return(
           status: 200,
           body: {


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/17](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/17)

To fix the problem, the regular expression on line 179 should be updated so that the dots are escaped (`\.`), thus matching only literal dots, and not any character. The best fix is to change `/generativelanguage.googleapis.com/` to `/generativelanguage\.googleapis\.com/`, ensuring the regex matches only the intended host. This change should be applied directly on line 179 of `test/integration/newmodels.rb`. No imports are needed, since Ruby's regex engine supports escaping by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
