### PR TITLE
Potential fix for code scanning alert no. 21: Incomplete regular expression for hostnames

### DIFF
--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -568,7 +568,7 @@ class TestClient < Minitest::Test
     end
 
     # Stub the API request
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 200,
         body: @success_response.to_json,


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/21](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/21)

To fix the problem, the regular expression in the `stub_request` call—currently `/generativelanguage.googleapis.com/`—should have any `.` that is meant to represent a literal period (dot) escaped as `\.`. This way, only the exact host `generativelanguage.googleapis.com` will be matched by the stub, and no unintended hosts that differ by one character will match. No additional methods or complex changes are required, just a single-character change to the regex in place.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
