### PR TITLE
Potential fix for code scanning alert no. 20: Incomplete regular expression for hostnames

### DIFF
--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -528,7 +528,7 @@ class TestClient < Minitest::Test
   end
 
   def test_generate_content_api_error
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 400,
         body: @error_response.to_json,
@@ -543,7 +543,7 @@ class TestClient < Minitest::Test
   end
 
   def test_generate_content_network_error
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_raise(HTTParty::Error.new('Network error'))
 
     error = assert_raises(GeminiAI::Error) do
@@ -568,7 +568,7 @@ class TestClient < Minitest::Test
     end
 
     # Stub the API request
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 200,
         body: @success_response.to_json,


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/20](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/20)

You should escape the dots in the regex used to match the domain in `stub_request` calls on lines 531 and 546 of `test/unit/client_test.rb`. This changes `/generativelanguage.googleapis.com/` to `/generativelanguage\.googleapis\.com/`. This ensures only requests to `generativelanguage.googleapis.com` are matched, avoiding unintended matches to similar but incorrect domains. No imports or additional methods are needed; just update these stub_request lines.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
