### PR TITLE
Potential fix for code scanning alert no. 19: Incomplete regular expression for hostnames

### DIFF
--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -528,7 +528,7 @@ class TestClient < Minitest::Test
   end
 
   def test_generate_content_api_error
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 400,
         body: @error_response.to_json,
@@ -543,7 +543,7 @@ class TestClient < Minitest::Test
   end
 
   def test_generate_content_network_error
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_raise(HTTParty::Error.new('Network error'))
 
     error = assert_raises(GeminiAI::Error) do


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/19](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/19)

To fix this issue, all uses of the regular expression to match hostnames (such as `/generativelanguage.googleapis.com/` and `/generativelanguage\.googleapis\.com/`) should escape all periods with a backslash (`\.`), so that each `.` matches only a literal period and not any character. In practice, this means that the regular expression should become `/generativelanguage\.googleapis\.com/`. Update each instance in `test/unit/client_test.rb` where such a regular expression appears (lines 488, 511, 531, 546).

No new imports or external dependencies are required. Only the regex literals need to be updated so that all `.` (periods) in hostnames are replaced with `\.`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
