### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete regular expression for hostnames

### DIFF
--- a/test/integration/api.rb
+++ b/test/integration/api.rb
@@ -29,7 +29,7 @@ class TestAPI < Minitest::Test
     }
 
     # Stub the API request
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 200,
         body: @success_response.to_json,
@@ -48,7 +48,7 @@ class TestAPI < Minitest::Test
 
   def test_chat_functionality
     # Stub the API request with the expected response
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 200,
         body: {


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/12](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/12)

To fix the problem, the regex `/generativelanguage.googleapis.com/` should be updated to escape the dots that are intended to be literal. Specifically, each `.` in the domain should be replaced by `\.` in the regex, resulting in `/generativelanguage\.googleapis\.com/`. This restricts matches to exactly the intended hostname. The same fix should be applied consistently throughout the file wherever this pattern appears (such as line 51 as well). No additional dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
