### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete regular expression for hostnames

### DIFF
--- a/test/integration/api.rb
+++ b/test/integration/api.rb
@@ -109,7 +109,7 @@ class TestAPI < Minitest::Test
 
   def test_system_instructions
     # Stub the request
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .with(body: hash_including({
                                    'contents' => [{
                                      'role' => 'user',
@@ -157,7 +157,7 @@ class TestAPI < Minitest::Test
     base64_image = 'base64_encoded_image_here'
 
     # Stub the API request for image analysis
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .with(body: hash_including({
                                    contents: [{
                                      parts: [
@@ -199,7 +199,7 @@ class TestAPI < Minitest::Test
     end
 
     # Stub API error response
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 400,
         body: {


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/16](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/16)

To fix the problem, we need to escape each `.` in the hostname so that the regular expression matches a literal dot rather than any character. In Ruby regular expressions, this is done using a backslash: `\.`. Therefore, `/generativelanguage.googleapis.com/` should become `/generativelanguage\.googleapis\.com/`. This precise expression will only match URLs that contain the exact hostname and not unintended variations.

Specifically, all instances in `test/integration/api.rb` where `/generativelanguage.googleapis.com/` appears as a regular expression should be replaced with `/generativelanguage\.googleapis\.com/`. No imports or extra definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
