### PR TITLE
Potential fix for code scanning alert no. 14: Incomplete regular expression for hostnames

### DIFF
--- a/test/integration/api.rb
+++ b/test/integration/api.rb
@@ -29,7 +29,7 @@ class TestAPI < Minitest::Test
     }
 
     # Stub the API request
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 200,
         body: @success_response.to_json,
@@ -48,7 +48,7 @@ class TestAPI < Minitest::Test
 
   def test_chat_functionality
     # Stub the API request with the expected response
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .to_return(
         status: 200,
         body: {
@@ -78,7 +78,7 @@ class TestAPI < Minitest::Test
 
   def test_different_models
     # Stub the request for each model with different responses
-    stub_request(:post, /generativelanguage.googleapis.com/)
+    stub_request(:post, /generativelanguage\.googleapis\.com/)
       .with(body: hash_including({
                                    'contents' => [{
                                      'parts' => [{ 'text' => 'What is the weather like?' }]


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/14](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/14)

To fix this issue, you should escape the dots in the host portion of the regular expression so it matches the literal `.` character, not any character. Specifically, change `/generativelanguage.googleapis.com/` to `/generativelanguage\.googleapis\.com/` to precisely match the intended host. This change should be made wherever the stubbed request uses a regex to match the hostname—including at lines 32, 51, and 81 in your provided snippet (test/integration/api.rb). No new imports or gems are required, only the small edit to the regular expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
