### PR TITLE
feat: Add Gemini CLI integration

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -1,0 +1,23 @@
+name: Gemini CLI Integration
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  run-gemini-cli:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Run Gemini CLI
+      uses: google-github-actions/run-gemini-cli@v0.1.12
+      with:
+        # Add your Gemini CLI command here
+        command: version
+        # Uncomment and set your API key if needed
+        # api_key: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Changes
- Added GitHub Actions workflow for Gemini CLI integration
- Configured workflow to run on PRs to main and pushes to main
- Initial setup with version command

## Testing
- [ ] Verify workflow runs successfully
- [ ] Test with actual Gemini CLI commands

## Notes
- API key needs to be configured in repository secrets as GEMINI_API_KEY