### PR TITLE
Potential fix for code scanning alert no. 30: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -113,7 +113,7 @@ jobs:
           
           # Upload results as artifact
           if [ -f "./gitleaks-results.sarif" ]; then
-            echo "GITLEAKS_RESULTS=$(cat ./gitleaks-results.sarif | jq -c '.' | base64 -w 0)" >> $GITHUB_ENV
+            echo "GITLEAKS_RESULTS=$(cat ./gitleaks-results.sarif | jq -c '.' | base64 -w 0 | tr -d '\n')" >> $GITHUB_ENV
             echo "Gitleaks scan completed. Results saved to gitleaks-results.sarif"
           else
             echo "No Gitleaks results file was generated."


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/30](https://github.com/bniladridas/friday_gemini_ai/security/code-scanning/30)

To prevent environment variable injection, we must ensure that the value assigned to `GITLEAKS_RESULTS` is always single-line and cannot break out of its assignment in the `$GITHUB_ENV` file.  
**Best fix:**  
After generating the SARIF file and before assigning it to the environment variable, sanitize the output to remove all newline characters. In Bash, this can be done using `tr -d '\n'`. The command should be changed to:
```bash
echo "GITLEAKS_RESULTS=$(cat ./gitleaks-results.sarif | jq -c '.' | base64 -w 0 | tr -d '\n')" >> $GITHUB_ENV
```
This ensures any newlines are stripped before writing to `$GITHUB_ENV`. Only the relevant line(s) inside the step should be changed.

**Summary of changes:**
- In the "Install and run Gitleaks" step, replace the line that sets `GITLEAKS_RESULTS` so that it pipes the output through `tr -d '\n'`.

No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
