### PR TITLE
Test Harper reorganization - verify bot works with new file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ The analysis output includes:
    - `GEMINI_API_KEY`: Your Google Gemini API key
    - `GITHUB_TOKEN` (automatically provided by GitHub)
 
-2. The workflow is configured in `.github/workflows/codebot.yml` and runs HarperBot automatically on pull requests and pushes to main.
+2. The workflow is configured in `.harper/codebot.yml` and runs HarperBot automatically on pull requests and pushes to main.
+
+   > **Note**: HarperBot files are now organized in the `.harper/` directory for better structure.
 
 ### Workflow Triggers
 


### PR DESCRIPTION
This PR tests the reorganization of HarperBot files from `.github` to `.harper` directory.

## Changes Made:
- Moved PR bot files to `.harper/` directory:
  - `scripts/pr_bot.py` → `.harper/pr_bot.py`
  - `workflows/codebot.yml` → `.harper/codebot.yml`
  - `PR_BOT.md` → `.harper/PR_BOT.md`
  - `PRTEMPLATE.md` → `.harper/PRTEMPLATE.md`

## Updates:
- Updated CODEOWNERS to include `.harper/` directory
- Updated documentation references to new paths
- Updated workflow file to reference new script location
- Added note in README about new directory structure

## Purpose:
Test that HarperBot can still find and execute files from the new `.harper` directory location.

## Test Change:
- Added documentation note about the new structure