### PR TITLE
Fix HarperBot to use GitHub App for proper bot posting

### DIFF
--- a/.harper/PR_BOT.md
+++ b/.harper/PR_BOT.md
@@ -12,12 +12,18 @@ This bot automatically analyzes pull requests using Google's Gemini AI and posts
 
 ## Setup
 
-1. **Bot Account**
-   Create a dedicated GitHub account for HarperBot (e.g., @harper-bot) to post comments as a custom user instead of github-actions.
+1. **GitHub App**
+   Create a GitHub App for HarperBot to post comments as a dedicated bot:
+   - Go to https://github.com/settings/apps
+   - Create a new GitHub App named "HarperBot"
+   - Set permissions: Repository permissions - Issues: Read & Write, Pull requests: Read & Write
+   - Generate and download a private key
+   - Install the app on your repository
 
 2. **Required Secrets**
    - `GEMINI_API_KEY`: Your Google Gemini API key
-   - `HARPER_BOT_TOKEN`: Personal Access Token from the HarperBot account (with repo, issues, pull_requests scopes)
+   - `HARPER_BOT_APP_ID`: The App ID from the GitHub App settings
+   - `HARPER_BOT_PRIVATE_KEY`: The private key content (paste the entire .pem file content)
 
 3. **Installation**
    The bot is automatically set up to run on pull requests. No additional installation is needed.

--- a/.harper/PR_BOT.md
+++ b/.harper/PR_BOT.md
@@ -16,7 +16,7 @@ This bot automatically analyzes pull requests using Google's Gemini AI and posts
    Create a GitHub App for HarperBot to post comments as a dedicated bot:
    - Go to https://github.com/settings/apps
    - Create a new GitHub App named "HarperBot"
-   - Set permissions: Repository permissions - Issues: Read & Write, Pull requests: Read & Write
+   - Set permissions: Repository permissions - Contents: Read, Issues: Read & Write, Pull requests: Read & Write
    - Generate and download a private key
    - Install the app on your repository
 

--- a/.harper/PR_BOT.md
+++ b/.harper/PR_BOT.md
@@ -14,7 +14,7 @@ This bot automatically analyzes pull requests using Google's Gemini AI and posts
 
 1. **GitHub App**
    Create a GitHub App for HarperBot to post comments as a dedicated bot:
-   - Go to https://github.com/settings/apps
+   - Go to https://github.com/settings/apps (for personal accounts) or your organization's settings to create a new GitHub App.
    - Create a new GitHub App named "HarperBot"
    - Set permissions: Repository permissions - Contents: Read, Issues: Read & Write, Pull requests: Read & Write
    - Generate and download a private key

--- a/.harper/codebot.yml
+++ b/.harper/codebot.yml
@@ -134,21 +134,28 @@ jobs:
         python --version
         pip --version
 
-    - name: Debug GitHub identity
-      env:
-        GITHUB_TOKEN: ${{ secrets.HARPER_BOT_TOKEN }}
-      run: |
-        python3 - <<'EOF'
-        from github import Github, Auth
-        import os
-        g = Github(auth=Auth.Token(os.getenv("GITHUB_TOKEN")))
-        print("Authenticated as:", g.get_user().login)
-        EOF
+     - name: Generate GitHub App Token
+       id: app-token
+       uses: actions/create-github-app-token@v1
+       with:
+         app-id: ${{ secrets.HARPER_BOT_APP_ID }}
+         private-key: ${{ secrets.HARPER_BOT_PRIVATE_KEY }}
 
-    - name: Run Gemini PR Bot
-      env:
-        GITHUB_TOKEN: ${{ secrets.HARPER_BOT_TOKEN }}
-        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+     - name: Debug GitHub identity
+       run: |
+         python3 - <<'EOF'
+         from github import Github, Auth
+         import os
+         g = Github(auth=Auth.Token(os.getenv("GITHUB_TOKEN")))
+         print("Authenticated as:", g.get_user().login)
+         EOF
+       env:
+         GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+     - name: Run Gemini PR Bot
+       env:
+         GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: |
         # Verify installations
         echo "Node.js: $(node --version)"

--- a/.harper/codebot.yml
+++ b/.harper/codebot.yml
@@ -134,28 +134,28 @@ jobs:
         python --version
         pip --version
 
-     - name: Generate GitHub App Token
-       id: app-token
-       uses: actions/create-github-app-token@v1
-       with:
-         app-id: ${{ secrets.HARPER_BOT_APP_ID }}
-         private-key: ${{ secrets.HARPER_BOT_PRIVATE_KEY }}
+    - name: Generate GitHub App Token
+      id: app-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.HARPER_BOT_APP_ID }}
+        private-key: ${{ secrets.HARPER_BOT_PRIVATE_KEY }}
 
-     - name: Debug GitHub identity
-       run: |
-         python3 - <<'EOF'
-         from github import Github, Auth
-         import os
-         g = Github(auth=Auth.Token(os.getenv("GITHUB_TOKEN")))
-         print("Authenticated as:", g.get_user().login)
-         EOF
-       env:
-         GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+    - name: Debug GitHub identity
+      run: |
+        python3 - <<'EOF'
+        from github import Github, Auth
+        import os
+        g = Github(auth=Auth.Token(os.getenv("GITHUB_TOKEN")))
+        print("Authenticated as:", g.get_user().login)
+        EOF
+      env:
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-     - name: Run Gemini PR Bot
-       env:
-         GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+    - name: Run Gemini PR Bot
+      env:
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: |
         # Verify installations
         echo "Node.js: $(node --version)"


### PR DESCRIPTION
Switch from PAT to GitHub App to allow comments to post as the dedicated bot account instead of github-actions.