### PR TITLE
Update HarperBot workflow to use GitHub App token

### DIFF
--- a/.github/workflows/codebot.yml
+++ b/.github/workflows/codebot.yml
@@ -134,9 +134,27 @@ jobs:
         python --version
         pip --version
 
+    - name: Generate GitHub App Token
+      id: app-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.HARPER_BOT_APP_ID }}
+        private-key: ${{ secrets.HARPER_BOT_PRIVATE_KEY }}
+
+    - name: Debug GitHub identity
+      run: |
+        python3 - <<'EOF'
+        from github import Github, Auth
+        import os
+        g = Github(auth=Auth.Token(os.getenv("GITHUB_TOKEN")))
+        print("Authenticated as:", g.get_user().login)
+        EOF
+      env:
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
     - name: Run Gemini PR Bot
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: |
         # Verify installations


### PR DESCRIPTION
Update the workflow to generate and use GitHub App token for posting comments as the bot account.