### PR TITLE
fix: unfreeze lockfile before dependency updates in CI

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Update dependencies
          run: |
-            bundle update --conservative
-            bundle clean
+           bundle update --conservative
+           bundle clean
 
       - name: Run tests
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -43,6 +43,7 @@ jobs:
           bundle update --conservative
           bundle clean
 
+      # Refreeze the lockfile to prevent accidental modifications outside of this update process
       - name: Refreeze lockfile
         run: bundle config set frozen true
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -31,13 +31,16 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
-      - name: Update Bundler
-        run: gem update bundler
+       - name: Update Bundler
+         run: gem update bundler
 
-      - name: Update dependencies
-        run: |
-          bundle update --conservative
-          bundle clean
+       - name: Unfreeze lockfile
+         run: bundle config set frozen false
+
+       - name: Update dependencies
+         run: |
+           bundle update --conservative
+           bundle clean
 
       - name: Run tests
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Update dependencies
          run: |
-           bundle update --conservative
-           bundle clean
+            bundle update --conservative
+            bundle clean
 
       - name: Run tests
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -31,13 +31,13 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
-       - name: Update Bundler
-         run: gem update bundler
+      - name: Update Bundler
+        run: gem update bundler
 
-       - name: Unfreeze lockfile
-         run: bundle config set frozen false
+      - name: Unfreeze lockfile
+        run: bundle config set frozen false
 
-       - name: Update dependencies
+      - name: Update dependencies
          run: |
            bundle update --conservative
            bundle clean

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -38,9 +38,9 @@ jobs:
         run: bundle config set frozen false
 
       - name: Update dependencies
-         run: |
-           bundle update --conservative
-           bundle clean
+        run: |
+          bundle update --conservative
+          bundle clean
 
       - name: Run tests
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Update Bundler
         run: gem update bundler
 
+      # Unfreeze the lockfile to allow bundle update to modify Gemfile.lock
       - name: Unfreeze lockfile
         run: bundle config set frozen false
 
@@ -41,6 +42,9 @@ jobs:
         run: |
           bundle update --conservative
           bundle clean
+
+      - name: Refreeze lockfile
+        run: bundle config set frozen true
 
       - name: Run tests
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -14,6 +14,8 @@ jobs:
   # Update Ruby gem dependencies weekly
   update:
     name: Update
+    # The lockfile is temporarily unfrozen to allow bundle update to modify Gemfile.lock,
+    # then refrozen to prevent accidental modifications outside of this update process
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
This PR fixes the dependencies workflow by adding a step to unfreeze the lockfile before running bundle update --conservative. This resolves the frozen mode error that was preventing dependency updates.