### PR TITLE
Remove Gemini 1.5 Family Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,7 @@ image_client = GeminiAI::Client.new(model: :pro_1_5)  # For image analysis
 GeminiAI::Client.new(model: :pro)    # Gemini 2.5 Pro
 GeminiAI::Client.new(model: :flash)  # Gemini 2.5 Flash
 
-# Image analysis
-GeminiAI::Client.new(model: :pro_1_5)  # Gemini 1.5 Pro
-
 # Lightweight options
-GeminiAI::Client.new(model: :flash_1_5)  # Gemini 1.5 Flash
-GeminiAI::Client.new(model: :flash_8b)   # Compact model
 
 # Legacy options
 GeminiAI::Client.new(model: :flash_2_0)  # Gemini 2.0 Flash
@@ -60,9 +55,6 @@ GeminiAI::Client.new(model: :flash_lite) # Gemini 2.0 Flash Lite
 | ------------ | ---------------------- | ------------------------------- |
 | `:pro`        | `gemini-2.5-pro`        | Most capable, complex reasoning |
 | `:flash`      | `gemini-2.5-flash`      | Fast, general-purpose           |
-| `:pro_1_5`    | `gemini-1.5-pro`        | Image-to-text                   |
-| `:flash_1_5`  | `gemini-1.5-flash`      | Lightweight tasks               |
-| `:flash_8b`   | `gemini-1.5-flash-8b`   | Compact, efficient              |
 | `:flash_2_0`  | `gemini-2.0-flash`      | Legacy support                  |
 | `:flash_lite` | `gemini-2.0-flash-lite` | Lightweight legacy              |
 
@@ -76,7 +68,7 @@ GeminiAI::Client.new(model: :flash_lite) # Gemini 2.0 Flash Lite
 ## Features
 
 * **Multiple Model Support**
-  - Gemini 2.5, 2.0, and 1.5 families
+  - Gemini 2.5 and 2.0 families
   - Automatic model selection based on task
   - Backward compatibility with legacy models
 

--- a/lib/core/client.rb
+++ b/lib/core/client.rb
@@ -23,10 +23,7 @@ module GeminiAI
       # Legacy aliases for backward compatibility
       pro_2_0: 'gemini-2.0-flash',
 
-      # Gemini 1.5 models (for specific use cases)
-      pro_1_5: 'gemini-1.5-pro',
-      flash_1_5: 'gemini-1.5-flash',
-      flash_8b: 'gemini-1.5-flash-8b'
+
     }.freeze
 
     # Configure logging
@@ -102,8 +99,8 @@ module GeminiAI
         generationConfig: build_generation_config(options)
       }
 
-      # Use the pro_1_5 model for image-to-text tasks
-      send_request(request_body, model: :pro_1_5)
+       # Use the pro model for image-to-text tasks
+       send_request(request_body, model: :pro)
     end
 
     def chat(messages, options = {})

--- a/scripts/summary.rb
+++ b/scripts/summary.rb
@@ -36,7 +36,7 @@ puts <<~RUBY
 
   # Use specific versions
   client = GeminiAI::Client.new(model: :flash_2_0)  # Gemini 2.0 Flash
-  client = GeminiAI::Client.new(model: :pro_1_5)    # Gemini 1.5 Pro
+  client = GeminiAI::Client.new(model: :pro)    # Gemini 2.5 Pro
 RUBY
 
 puts "\nAvailable Scripts:"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -182,7 +182,7 @@ module Minitest
       debug_puts "Body: #{response_body}\n\n"
 
       stub.to_return(
-        status:,
+        status: status,
         body: response_body,
         headers: { 'Content-Type' => 'application/json' }
       )
@@ -305,7 +305,7 @@ module Minitest
 
   # Helper method to create a test client
   def create_test_client(model: :pro, **)
-    GeminiAI::Client.new('test_key', model:, **)
+    GeminiAI::Client.new('test_key', model: model)
   end
 end
 

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -412,7 +412,7 @@ class TestClient < Minitest::Test
     # Use the same API key that's used in the test client
     api_key = @client.instance_variable_get('@api_key')
 
-    stub_request(:post, "https://generativelanguage.googleapis.com/v1/models/gemini-1.5-pro:generateContent?key=#{api_key}")
+    stub_request(:post, "https://generativelanguage.googleapis.com/v1/models/gemini-2.5-pro:generateContent?key=#{api_key}")
       .with(
         headers: {
           'Accept' => '*/*',


### PR DESCRIPTION
## Summary
- Remove support for Gemini 1.5 family models (pro_1_5, flash_1_5, flash_8b)
- Update image-to-text functionality to use Gemini 2.5 Pro instead
- Clean up documentation and examples
- Fix minor syntax issues in test helpers

This change focuses the library on the latest Gemini 2.5 and 2.0 model families, removing legacy 1.5 support.