### PR TITLE
fix: correct require statement in Friday Gemini AI

### DIFF
--- a/lib/friday_gemini_ai.rb
+++ b/lib/friday_gemini_ai.rb
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 friday_gemini_ai
+
+# frozen_string_literal: true
+
+# Main entry point for the friday_gemini_ai gem
+require_relative 'gemini'


### PR DESCRIPTION

We fixed the  statement issue by creating the missing  file. This file simply requires , which loads the main module. Now,  works as shown in the documentation and follows standard Ruby gem conventions.

The gem builds successfully, and examples run correctly for users with compatible Ruby versions (>= 3.1). This ensures consistency between the code, documentation, and expected usage.
