### PR TITLE
fix: align sanitizer cap with 8k gemini output budget

### DIFF
--- a/harperbot/config.yaml
+++ b/harperbot/config.yaml
@@ -26,7 +26,7 @@ temperature: 0.2
 
 # Maximum output tokens
 # Maximum length of AI response in tokens. Higher allows more detailed analysis but increases cost.
-max_output_tokens: 4096
+max_output_tokens: 8192
 
 # Safety settings for AI content filtering
 # Configure thresholds: BLOCK_NONE, BLOCK_ONLY_HIGH, BLOCK_MEDIUM_AND_ABOVE, BLOCK_LOW_AND_ABOVE

--- a/harperbot/harperbot.py
+++ b/harperbot/harperbot.py
@@ -238,7 +238,7 @@ Provide a concise code review analysis in this format:
         "model": "gemini-2.5-flash",
         "max_diff_length": 4000,
         "temperature": 0.2,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         # When enabled, a manual `/analyze` will post a new PR review even if one already exists
         # for the current head SHA. This can create extra reviews; prefer `/analyze --force-review`
         # for one-off reruns.
@@ -275,7 +275,7 @@ def analyze_with_gemini(client, pr_details):
         focus = config.get("focus", "all")
         max_diff = config.get("max_diff_length", 4000)
         temperature = config.get("temperature", 0.2)
-        max_output_tokens = config.get("max_output_tokens", 4096)
+        max_output_tokens = config.get("max_output_tokens", 8192)
         safety_settings = config.get("safety_settings", [])
 
         # Auto-select model based on PR complexity
@@ -368,8 +368,12 @@ def analyze_with_gemini(client, pr_details):
             try:
                 # Try the standard text accessor first
                 if getattr(resp, "text", None):
-                    logging.debug("Extracted text from direct response.text")
-                    return sanitize_text(resp.text.strip())
+                    text = resp.text.strip()
+                    logging.debug(f"Extracted text from direct response.text (length: {len(text)})")
+                    # Check if text ends abruptly (might indicate incomplete response)
+                    if len(text) > 50 and not text.endswith((".", "!", "?", "\n", "```")):
+                        logging.warning(f"Response text appears incomplete - ends with: '{text[-50:]}'")
+                    return sanitize_text(text)
 
                 # Try candidates structure (most common for Gemini API)
                 candidates = getattr(resp, "candidates", None)
@@ -380,16 +384,26 @@ def analyze_with_gemini(client, pr_details):
                         if content and getattr(content, "parts", None):
                             parts = [getattr(part, "text", "") for part in content.parts if getattr(part, "text", None)]
                             if parts:
-                                logging.debug(f"Extracted text from candidate {i}")
-                                return sanitize_text("\n".join(parts).strip())
+                                text = "\n".join(parts).strip()
+                                logging.debug(f"Extracted text from candidate {i} (length: {len(text)})")
+                                # Check if text ends abruptly
+                                if len(text) > 50 and not text.endswith((".", "!", "?", "\n", "```")):
+                                    logging.warning(
+                                        f"Response text from candidate {i} appears incomplete - ends with: '{text[-50:]}'"
+                                    )
+                                return sanitize_text(text)
 
                 # Try direct parts access as fallback
                 parts = getattr(resp, "parts", None)
                 if parts:
                     parts = [getattr(part, "text", "") for part in parts if getattr(part, "text", None)]
                     if parts:
-                        logging.debug("Extracted text from direct response.parts")
-                        return sanitize_text("\n".join(parts).strip())
+                        text = "\n".join(parts).strip()
+                        logging.debug(f"Extracted text from direct response.parts (length: {len(text)})")
+                        # Check if text ends abruptly
+                        if len(text) > 50 and not text.endswith((".", "!", "?", "\n", "```")):
+                            logging.warning(f"Response text from direct parts appears incomplete - ends with: '{text[-50:]}'")
+                        return sanitize_text(text)
 
                 logging.warning("No text found in any response structure")
             except Exception as extract_error:
@@ -407,28 +421,43 @@ def analyze_with_gemini(client, pr_details):
             text = re.sub(r"<[^>]+>", "", text)  # Remove all HTML tags
             text = re.sub(r"javascript:", "", text, flags=re.IGNORECASE)
             text = re.sub(r"on\w+\s*=", "", text, flags=re.IGNORECASE)  # Remove event handlers
-            # Limit length to prevent abuse (increased to accommodate AI output limits)
-            if len(text) > 20000:
-                text = text[:20000] + "... (truncated for length)"
+            # Keep the character cap aligned with the configured token budget.
+            max_sanitized_chars = max(20000, max_output_tokens * 4)
+            if len(text) > max_sanitized_chars:
+                logging.warning(
+                    "Sanitized Gemini response exceeded %s chars; truncating to fit downstream limits",
+                    max_sanitized_chars,
+                )
+                text = text[:max_sanitized_chars] + "... (truncated for length)"
             return text.strip()
 
         try:
             text = extract_text(response)
             if text:
+                # Additional check for potentially incomplete responses
+                if len(text) < 100 and not any(
+                    indicator in text.lower() for indicator in ["analysis", "review", "summary", "changes"]
+                ):
+                    logging.warning(f"Response seems too short and may be incomplete (length: {len(text)}): {text[:200]}")
                 return text
 
-            # Check for finish reasons that indicate no content
+            # Check for finish reasons that indicate truncation or issues
             candidates = getattr(response, "candidates", None)
             if candidates:
                 for candidate in candidates:
                     finish_reason = getattr(candidate, "finish_reason", None)
                     if finish_reason:
-                        if "MAX_TOKENS" in str(finish_reason):
+                        finish_str = str(finish_reason).upper()
+                        if "MAX" in finish_str and "TOKEN" in finish_str:
+                            logging.warning(f"Analysis truncated due to token limit (finish_reason: {finish_reason})")
                             return "Analysis truncated due to token limit. The code changes are too extensive for a complete analysis. Please review manually or split into smaller PRs."
-                        elif "SAFETY" in str(finish_reason):
+                        elif "SAFETY" in finish_str:
+                            logging.warning(f"Analysis blocked due to safety filters (finish_reason: {finish_reason})")
                             return "Analysis blocked due to content safety filters. Please ensure the PR content complies with usage policies."
-                        elif "STOP" in str(finish_reason):
-                            return "Analysis completed but no content was generated. This may indicate an issue with the prompt or model."
+                        elif "STOP" in finish_str:
+                            logging.info(f"Analysis completed normally (finish_reason: {finish_reason})")
+                        else:
+                            logging.warning(f"Unexpected finish_reason: {finish_reason}")
 
             # If we get here, no text found - log and return safe message
             logging.warning(f"No text extracted from response. Response type: {type(response)}")
@@ -972,7 +1001,12 @@ def post_inline_suggestions(pr, pr_details, suggestions, g, repo, *, force_revie
             return
 
         try:
-            pr.create_review(commit=commit, body=review_body, comments=review_comments, event="COMMENT")
+            pr.create_review(
+                commit=commit,
+                body=review_body,
+                comments=review_comments,
+                event="COMMENT",
+            )
             logging.info(f"Posted {len(review_comments)} inline suggestions as a review")
         except Exception as e:
             # Fallback to legacy `position` field if the API rejects line-based comments.
@@ -993,7 +1027,12 @@ def post_inline_suggestions(pr, pr_details, suggestions, g, repo, *, force_revie
                 position_comments.append({"path": file_path, "position": position, "body": body})
 
             if position_comments:
-                pr.create_review(commit=commit, body=review_body, comments=position_comments, event="COMMENT")
+                pr.create_review(
+                    commit=commit,
+                    body=review_body,
+                    comments=position_comments,
+                    event="COMMENT",
+                )
                 logging.info(f"Posted {len(position_comments)} inline suggestions as a review (position fallback)")
             else:
                 pr.create_review(commit=commit, body=review_body, event="COMMENT")
@@ -1291,7 +1330,13 @@ def handle_pr_comment_command(
         logging.info(f"Processing /analyze for PR #{pr_number} in {repo_name}")
         force_review = ("--force-review" in command_args) or ("--force_review" in command_args)
         try:
-            run_analysis_for_pr(installation_id, repo_name, pr_number, force=True, force_review=force_review)
+            run_analysis_for_pr(
+                installation_id,
+                repo_name,
+                pr_number,
+                force=True,
+                force_review=force_review,
+            )
             return {"status": "ok"}, 200
         except Exception as e:
             logging.error(f"Error processing /analyze: {str(e)}")

--- a/test/test_harperbot.py
+++ b/test/test_harperbot.py
@@ -67,7 +67,7 @@ class TestHarperBot(unittest.TestCase):
             self.assertEqual(config["model"], "gemini-2.5-flash")
             self.assertEqual(config["max_diff_length"], 4000)
             self.assertEqual(config["temperature"], 0.2)
-            self.assertEqual(config["max_output_tokens"], 4096)
+            self.assertEqual(config["max_output_tokens"], 8192)
             self.assertIn("prompt", config)  # Should include default prompt
 
     @patch("harperbot.harperbot.load_config")
@@ -90,7 +90,12 @@ class TestHarperBot(unittest.TestCase):
         mock_response.text = "Test analysis"
         mock_client.models.generate_content.return_value = mock_response
 
-        pr_details = {"title": "Test PR", "body": "Test body", "files_changed": ["test.py"], "diff": "test diff"}
+        pr_details = {
+            "title": "Test PR",
+            "body": "Test body",
+            "files_changed": ["test.py"],
+            "diff": "test diff",
+        }
 
         result = analyze_with_gemini(mock_client, pr_details)
         self.assertEqual(result, "Test analysis")
@@ -117,9 +122,18 @@ class TestHarperBot(unittest.TestCase):
         mock_response.text = "Recovered analysis"
 
         server_error = genai_errors.ServerError(503, {"error": {"message": "unavailable", "status": "UNAVAILABLE"}}, None)
-        mock_client.models.generate_content.side_effect = [server_error, server_error, mock_response]
+        mock_client.models.generate_content.side_effect = [
+            server_error,
+            server_error,
+            mock_response,
+        ]
 
-        pr_details = {"title": "Test PR", "body": "Test body", "files_changed": ["test.py"], "diff": "test diff"}
+        pr_details = {
+            "title": "Test PR",
+            "body": "Test body",
+            "files_changed": ["test.py"],
+            "diff": "test diff",
+        }
         result = analyze_with_gemini(mock_client, pr_details)
         self.assertEqual(result, "Recovered analysis")
         self.assertEqual(mock_client.models.generate_content.call_count, 3)
@@ -144,7 +158,12 @@ class TestHarperBot(unittest.TestCase):
         server_error = genai_errors.ServerError(503, {"error": {"message": "unavailable", "status": "UNAVAILABLE"}}, None)
         mock_client.models.generate_content.side_effect = server_error
 
-        pr_details = {"title": "Test PR", "body": "Test body", "files_changed": ["test.py"], "diff": "test diff"}
+        pr_details = {
+            "title": "Test PR",
+            "body": "Test body",
+            "files_changed": ["test.py"],
+            "diff": "test diff",
+        }
         result = analyze_with_gemini(mock_client, pr_details)
         self.assertIn("api unavailable", result.lower())
         self.assertIn("http 503", result.lower())
@@ -167,7 +186,12 @@ class TestHarperBot(unittest.TestCase):
         mock_response.text = "OK"
         mock_client.models.generate_content.return_value = mock_response
 
-        pr_details = {"title": "Test PR", "body": "Test body", "files_changed": ["test.py"], "diff": "test diff"}
+        pr_details = {
+            "title": "Test PR",
+            "body": "Test body",
+            "files_changed": ["test.py"],
+            "diff": "test diff",
+        }
         result = analyze_with_gemini(mock_client, pr_details)
         self.assertEqual(result, "OK")
         _args, kwargs = mock_client.models.generate_content.call_args
@@ -175,6 +199,35 @@ class TestHarperBot(unittest.TestCase):
         self.assertIn("test.py", kwargs["contents"])
         self.assertIn("Diff:", kwargs["contents"])
         self.assertIn("test diff", kwargs["contents"])
+
+    @patch("harperbot.harperbot.load_config")
+    def test_analyze_with_gemini_keeps_large_response_with_8k_output_budget(self, mock_load_config):
+        """An 8k-token output budget should not be cut off by the sanitizer's char cap."""
+        mock_load_config.return_value = {
+            "model": "gemini-2.5-flash",
+            "focus": "all",
+            "max_diff_length": 4000,
+            "temperature": 0.2,
+            "max_output_tokens": 8192,
+            "prompt": "Test prompt {num_files} {files_list} {diff_content} {focus_instruction}",
+        }
+
+        mock_client = Mock()
+        mock_client.models = Mock()
+        mock_response = Mock()
+        mock_response.text = "A" * 25000
+        mock_client.models.generate_content.return_value = mock_response
+
+        pr_details = {
+            "title": "Test PR",
+            "body": "Test body",
+            "files_changed": ["test.py"],
+            "diff": "test diff",
+        }
+
+        result = analyze_with_gemini(mock_client, pr_details)
+        self.assertEqual(result, "A" * 25000)
+        self.assertNotIn("... (truncated for length)", result)
 
     def test_parse_diff_for_suggestions_valid(self):
         """Test parsing diff suggestions."""
@@ -475,12 +528,23 @@ class TestHarperBot(unittest.TestCase):
     def test_post_inline_suggestions_uses_line_based_comments_first(self):
         """Inline suggestions default to modern line-based review comments."""
         pr = Mock()
-        pr_details = {"head_sha": "deadbeef", "diff": "diff --git a/a.txt b/a.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n"}
+        pr_details = {
+            "head_sha": "deadbeef",
+            "diff": "diff --git a/a.txt b/a.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+        }
         repo = Mock()
         repo.get_commit.return_value = Mock()
 
         pr.get_reviews.return_value = []
-        suggestions = [{"path": "a.txt", "start_line": 1, "end_line": 1, "op": "replace", "suggestion": "new"}]
+        suggestions = [
+            {
+                "path": "a.txt",
+                "start_line": 1,
+                "end_line": 1,
+                "op": "replace",
+                "suggestion": "new",
+            }
+        ]
         post_inline_suggestions(pr, pr_details, suggestions, g=Mock(), repo=repo)
 
         _args, kwargs = pr.create_review.call_args
@@ -494,7 +558,10 @@ class TestHarperBot(unittest.TestCase):
     @patch("harperbot.harperbot.load_config")
     def test_post_comment_webhook_force_review_from_config(self, mock_load_config, mock_github, mock_post_inline):
         """Config can opt-in to reposting reviews on manual /analyze."""
-        mock_load_config.return_value = {"enable_authoring": False, "force_review_on_analyze": True}
+        mock_load_config.return_value = {
+            "enable_authoring": False,
+            "force_review_on_analyze": True,
+        }
 
         repo = Mock()
         pr = Mock()
@@ -516,7 +583,10 @@ class TestHarperBot(unittest.TestCase):
     @patch("harperbot.harperbot.load_config")
     def test_post_comment_webhook_force_review_explicit_arg(self, mock_load_config, mock_github, mock_post_inline):
         """Explicit force_review argument always wins."""
-        mock_load_config.return_value = {"enable_authoring": False, "force_review_on_analyze": False}
+        mock_load_config.return_value = {
+            "enable_authoring": False,
+            "force_review_on_analyze": False,
+        }
 
         repo = Mock()
         pr = Mock()
@@ -625,7 +695,10 @@ class TestHarperBot(unittest.TestCase):
         g.get_repo.return_value = repo
         repo.get_issue.return_value = issue
         issue.get_labels.return_value = []
-        issue.add_to_labels.side_effect = [GithubException(404, {"message": "Not Found"}, None), None]
+        issue.add_to_labels.side_effect = [
+            GithubException(404, {"message": "Not Found"}, None),
+            None,
+        ]
         mock_setup_env.return_value = (g, "token", Mock())
 
         result = handle_pr_comment_command(123, "o/r", 1, "/pause", "alice")
@@ -656,7 +729,11 @@ class TestHarperBot(unittest.TestCase):
 
     @patch("harperbot.harperbot.post_notice_comment")
     @patch("harperbot.harperbot.setup_environment_webhook")
-    @patch.dict("os.environ", {"VERCEL_GIT_COMMIT_SHA": "0123456789abcdef", "VERCEL_GIT_COMMIT_REF": "main"}, clear=False)
+    @patch.dict(
+        "os.environ",
+        {"VERCEL_GIT_COMMIT_SHA": "0123456789abcdef", "VERCEL_GIT_COMMIT_REF": "main"},
+        clear=False,
+    )
     def test_handle_pr_comment_command_status_shows_label_presence(self, mock_setup_env, mock_post_notice):
         g = Mock()
         repo = Mock()
@@ -719,7 +796,10 @@ class TestHarperBot(unittest.TestCase):
             self.assertFalse(config["enable_authoring"])
             self.assertFalse(config["auto_commit_suggestions"])
             self.assertFalse(config["create_improvement_prs"])
-            self.assertEqual(config["improvement_branch_pattern"], "harperbot-improvements-{timestamp}")
+            self.assertEqual(
+                config["improvement_branch_pattern"],
+                "harperbot-improvements-{timestamp}",
+            )
 
     def test_create_branch_success(self):
         """Test successful branch creation."""
@@ -744,7 +824,15 @@ class TestHarperBot(unittest.TestCase):
         mock_ref = Mock()
         mock_repo.get_git_ref.return_value = mock_ref
 
-        suggestions = [{"path": "test.py", "start_line": 1, "end_line": 1, "op": "replace", "suggestion": "new content"}]
+        suggestions = [
+            {
+                "path": "test.py",
+                "start_line": 1,
+                "end_line": 1,
+                "op": "replace",
+                "suggestion": "new content",
+            }
+        ]
 
         # Mock file content
         mock_file = Mock()
@@ -767,7 +855,15 @@ class TestHarperBot(unittest.TestCase):
         mock_ref = Mock()
         mock_repo.get_git_ref.return_value = mock_ref
 
-        suggestions = [{"path": "test.py", "start_line": 1, "end_line": 1, "op": "replace", "suggestion": "new line content"}]
+        suggestions = [
+            {
+                "path": "test.py",
+                "start_line": 1,
+                "end_line": 1,
+                "op": "replace",
+                "suggestion": "new line content",
+            }
+        ]
 
         # Mock file content with multiple lines
         mock_file = Mock()
@@ -827,7 +923,15 @@ class TestHarperBot(unittest.TestCase):
         mock_ref = Mock()
         mock_repo.get_git_ref.return_value = mock_ref
 
-        suggestions = [{"path": "test.py", "start_line": 10, "end_line": 10, "op": "replace", "suggestion": "new content"}]
+        suggestions = [
+            {
+                "path": "test.py",
+                "start_line": 10,
+                "end_line": 10,
+                "op": "replace",
+                "suggestion": "new content",
+            }
+        ]
 
         mock_file = Mock()
         mock_file.decoded_content.decode.return_value = "line 1\nline 2\nline 3"
@@ -849,7 +953,15 @@ class TestHarperBot(unittest.TestCase):
         mock_ref = Mock()
         mock_repo.get_git_ref.return_value = mock_ref
 
-        suggestions = [{"path": "test.py", "start_line": 2, "end_line": 2, "op": "delete", "suggestion": None}]
+        suggestions = [
+            {
+                "path": "test.py",
+                "start_line": 2,
+                "end_line": 2,
+                "op": "delete",
+                "suggestion": None,
+            }
+        ]
 
         mock_file = Mock()
         mock_file.decoded_content.decode.return_value = "line 1\nline 2\nline 3"


### PR DESCRIPTION
## Summary
- keep the sanitizer character cap aligned with the configured Gemini output budget
- preserve the 8k token config in both defaults and config.yaml without silently truncating larger analyses
- add a regression test covering a 25k-character response under the 8k-token budget

## Testing
- python -m pytest test/test_harperbot.py

## Context
This addresses the review finding that raising `max_output_tokens` to 8192 was still being undercut by `sanitize_text()` truncating responses above 20,000 characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced detection and warnings for incomplete AI responses with improved logging.

* **Improvements**
  * Doubled maximum output token limit from 4,096 to 8,192, enabling longer responses.
  * Implemented dynamic response truncation based on token budget instead of fixed character limits.
  * Refined handling of response completion status with more informative messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->