### PR TITLE
fix: stop printing raw api keys

### DIFF
--- a/lib/core/client.rb
+++ b/lib/core/client.rb
@@ -49,7 +49,6 @@ module GeminiAI
     end
 
     def initialize(api_key = nil, model: :pro)
-      puts "Initializing client with api_key: #{api_key.inspect}, model: #{model}"
       # Prioritize passed API key, then environment variable
       @api_key = api_key || ENV.fetch('GEMINI_API_KEY', nil)
 
@@ -64,7 +63,6 @@ module GeminiAI
       self.class.logger.debug("API Key length: #{@api_key&.length}")
 
       # Validate API key before proceeding
-      puts "About to validate API key: #{@api_key.inspect}"
       validate_api_key!
 
       @model = resolve_model(model)
@@ -154,16 +152,13 @@ module GeminiAI
     end
 
     def validate_api_key!
-      puts "Validating API key: #{@api_key.inspect}"
       if @api_key.nil? || @api_key.to_s.strip.empty?
-        puts 'API key is nil or empty'
         self.class.logger.error('API key is missing')
         raise Error, 'API key is required. Set GEMINI_API_KEY environment variable or pass key directly.'
       end
 
       # Optional: Add basic API key format validation
       unless valid_api_key_format?(@api_key)
-        puts 'API key format is invalid'
         self.class.logger.error('Invalid API key format')
         raise Error, 'Invalid API key format. Please check your key.'
       end
@@ -171,7 +166,6 @@ module GeminiAI
       # Optional: Check key length and complexity
       return unless @api_key.length < 40
 
-      puts 'API key is too short'
       self.class.logger.warn('Potentially weak API key detected')
     end
 

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -113,6 +113,17 @@ class TestClient < Minitest::Test
     assert_equal 'gemini-2.5-pro', @client.instance_variable_get(:@model)
   end
 
+  def test_initialization_does_not_print_api_key_to_stdout
+    GeminiAI::Client.any_instance.unstub(:validate_api_key!)
+
+    stdout, stderr = capture_io do
+      GeminiAI::Client.new(@api_key)
+    end
+
+    refute_includes stdout, @api_key, 'Raw API key should not be printed to stdout'
+    refute_includes stderr, @api_key, 'Raw API key should not be printed to stderr'
+  end
+
   def test_api_key_masking_in_logs
     # Create a StringIO to capture logs
     log_output = StringIO.new


### PR DESCRIPTION
## Summary
- remove direct stdout logging of raw Gemini API keys during client initialization and validation
- keep non-secret debug logging intact
- add a regression test to ensure the raw key is not printed to stdout or stderr

## Testing
- PATH=/opt/homebrew/opt/ruby@3.2/bin:$PATH /opt/homebrew/opt/ruby@3.2/bin/bundle _2.5.0_ exec ruby -Itest test/unit/client_test.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed debug output statements that were writing sensitive information to the console during client initialization and API key validation.

* **Tests**
  * Added test coverage to verify that API credentials are never exposed in standard output or error streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->