### PR TITLE
test: reset memoized client logger before capture_io

### DIFF
--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -115,6 +115,7 @@ class TestClient < Minitest::Test
 
   def test_initialization_does_not_print_api_key_to_stdout
     GeminiAI::Client.any_instance.unstub(:validate_api_key!)
+    GeminiAI::Client.instance_variable_set(:@logger, nil)
 
     stdout, stderr = capture_io do
       GeminiAI::Client.new(@api_key)


### PR DESCRIPTION
## Summary
- reset 's memoized logger before  in the stdout leak regression test
- ensure the test observes logger output as well as direct stdout and stderr writes

## Testing
- PATH=/opt/homebrew/opt/ruby@3.2/bin:$PATH /opt/homebrew/opt/ruby@3.2/bin/bundle _2.5.0_ exec ruby -Itest test/unit/client_test.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup for initialization verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->