### PR TITLE
fix: secure harperbot apply and update website copy

### DIFF
--- a/harperbot/harperbot.py
+++ b/harperbot/harperbot.py
@@ -1325,7 +1325,33 @@ def handle_pr_comment_command(
     command_args = {part.lower() for part in command_parts[1:]}
 
     if command == "/apply":
-        return handle_apply_comment(installation_id, repo_name, pr_number)
+        g, installation_token, _ = setup_environment_webhook(installation_id)
+        repo = g.get_repo(repo_name)
+        pr = repo.get_pull(pr_number)
+        config = load_config()
+
+        if not config.get("enable_authoring", False):
+            post_notice_comment(
+                installation_token,
+                repo_name,
+                pr_number,
+                "Authoring disabled",
+                "The `/apply` command is disabled unless `enable_authoring` is turned on.",
+            )
+            return {"status": "forbidden"}, 403
+
+        permission = get_commenter_permission(repo, commenter_login)
+        if permission not in {"admin", "write"}:
+            pr.create_issue_comment(
+                format_notice(
+                    "Insufficient permissions",
+                    "You need write/admin permissions to use `/apply`.",
+                )
+            )
+            logging.warning(f"User {commenter_login} lacks permission ({permission}) for /apply on PR #{pr_number}")
+            return {"status": "forbidden"}, 403
+
+        return handle_apply_comment(installation_id, repo_name, pr_number, commenter_login=commenter_login)
     if command == "/analyze":
         logging.info(f"Processing /analyze for PR #{pr_number} in {repo_name}")
         force_review = ("--force-review" in command_args) or ("--force_review" in command_args)
@@ -1463,6 +1489,21 @@ def ensure_label_exists(repo, name: str):
         status = getattr(e, "status", None)
         if status in {422, 409}:
             return
+        raise
+
+
+def get_commenter_permission(repo, commenter_login: str | None):
+    """Best-effort collaborator permission lookup for slash-command authorization."""
+    if not commenter_login:
+        return None
+
+    try:
+        return repo.get_collaborator_permission(commenter_login)
+    except GithubException as e:
+        status = getattr(e, "status", None)
+        if status in {403, 404}:
+            logging.warning(f"Permission lookup failed for user {commenter_login}; treating as unprivileged (status={status})")
+            return None
         raise
 
 

--- a/harperbot/harperbot.py
+++ b/harperbot/harperbot.py
@@ -1105,11 +1105,8 @@ def setup_environment_webhook(installation_id):
     return g, installation_auth.token, client
 
 
-def get_pr_details_webhook(g, repo_name, pr_number, installation_token: str | None = None):
-    """Fetch PR details using GitHub App authentication."""
-    repo = g.get_repo(repo_name)
-    pr = repo.get_pull(pr_number)
-
+def build_pr_details_from_pr(pr, installation_token: str | None = None):
+    """Build normalized PR details from an existing pull request object."""
     files_changed = [f.filename for f in pr.get_files()]
 
     # Get diff content using diff_url
@@ -1124,8 +1121,15 @@ def get_pr_details_webhook(g, repo_name, pr_number, installation_token: str | No
         "base": pr.base.ref,
         "head": pr.head.ref,
         "head_sha": pr.head.sha,
-        "number": pr_number,
+        "number": pr.number,
     }
+
+
+def get_pr_details_webhook(g, repo_name, pr_number, installation_token: str | None = None):
+    """Fetch PR details using GitHub App authentication."""
+    repo = g.get_repo(repo_name)
+    pr = repo.get_pull(pr_number)
+    return build_pr_details_from_pr(pr, installation_token=installation_token)
 
 
 def is_harperbot_comment(comment):
@@ -1325,32 +1329,6 @@ def handle_pr_comment_command(
     command_args = {part.lower() for part in command_parts[1:]}
 
     if command == "/apply":
-        g, installation_token, _ = setup_environment_webhook(installation_id)
-        repo = g.get_repo(repo_name)
-        pr = repo.get_pull(pr_number)
-        config = load_config()
-
-        if not config.get("enable_authoring", False):
-            post_notice_comment(
-                installation_token,
-                repo_name,
-                pr_number,
-                "Authoring disabled",
-                "The `/apply` command is disabled unless `enable_authoring` is turned on.",
-            )
-            return {"status": "forbidden"}, 403
-
-        permission = get_commenter_permission(repo, commenter_login)
-        if permission not in {"admin", "write"}:
-            pr.create_issue_comment(
-                format_notice(
-                    "Insufficient permissions",
-                    "You need write/admin permissions to use `/apply`.",
-                )
-            )
-            logging.warning(f"User {commenter_login} lacks permission ({permission}) for /apply on PR #{pr_number}")
-            return {"status": "forbidden"}, 403
-
         return handle_apply_comment(installation_id, repo_name, pr_number, commenter_login=commenter_login)
     if command == "/analyze":
         logging.info(f"Processing /analyze for PR #{pr_number} in {repo_name}")
@@ -1517,7 +1495,7 @@ def handle_merge_command(
     """Handle merge/rebase commands from PR comments."""
     g, _, _ = setup_environment_webhook(installation_id)
     repo = g.get_repo(repo_name)
-    permission = repo.get_collaborator_permission(commenter_login)
+    permission = get_commenter_permission(repo, commenter_login)
     if permission not in {"admin", "write"}:
         pr = repo.get_pull(pr_number)
         pr.create_issue_comment(

--- a/harperbot/harperbot_apply.py
+++ b/harperbot/harperbot_apply.py
@@ -33,9 +33,9 @@ def handle_apply_comment(installation_id, repo_name, pr_number, commenter_login=
         from harperbot.harperbot import (
             analyze_with_gemini,
             apply_suggestions_to_pr,
+            build_pr_details_from_pr,
             format_notice,
             get_commenter_permission,
-            get_pr_details_webhook,
             load_config,
             parse_code_suggestions,
             setup_environment_webhook,
@@ -68,7 +68,7 @@ def handle_apply_comment(installation_id, repo_name, pr_number, commenter_login=
             )
             return jsonify({"status": "forbidden"}), 403
 
-        pr_details = get_pr_details_webhook(g, repo_name, pr_number, installation_token=installation_token)
+        pr_details = build_pr_details_from_pr(pr, installation_token=installation_token)
         analysis = analyze_with_gemini(client, pr_details)
         suggestions = parse_code_suggestions(analysis)
 

--- a/harperbot/harperbot_apply.py
+++ b/harperbot/harperbot_apply.py
@@ -21,7 +21,7 @@ except ImportError:
 # from harperbot.harperbot import setup_environment_webhook, get_pr_details_webhook, analyze_with_gemini, parse_code_suggestions, apply_suggestions_to_pr
 
 
-def handle_apply_comment(installation_id, repo_name, pr_number):
+def handle_apply_comment(installation_id, repo_name, pr_number, commenter_login=None):
     """
     Handle /apply comment on PR: re-analyze and apply suggestions as HarperBot.
     """
@@ -33,18 +33,44 @@ def handle_apply_comment(installation_id, repo_name, pr_number):
         from harperbot.harperbot import (
             analyze_with_gemini,
             apply_suggestions_to_pr,
+            format_notice,
+            get_commenter_permission,
             get_pr_details_webhook,
+            load_config,
             parse_code_suggestions,
             setup_environment_webhook,
         )
 
         g, installation_token, client = setup_environment_webhook(installation_id)
+        repo = g.get_repo(repo_name)
+        pr = repo.get_pull(pr_number)
+        config = load_config()
+
+        if not config.get("enable_authoring", False):
+            pr.create_issue_comment(
+                format_notice(
+                    "Authoring disabled",
+                    "The `/apply` command is disabled unless `enable_authoring` is turned on.",
+                )
+            )
+            return jsonify({"status": "forbidden"}), 403
+
+        permission = get_commenter_permission(repo, commenter_login)
+        if permission not in {"admin", "write"}:
+            pr.create_issue_comment(
+                format_notice(
+                    "Insufficient permissions",
+                    "You need write/admin permissions to use `/apply`.",
+                )
+            )
+            logging.warning(
+                f"User {commenter_login or '<unknown>'} lacks permission ({permission}) for /apply on PR #{pr_number}"
+            )
+            return jsonify({"status": "forbidden"}), 403
+
         pr_details = get_pr_details_webhook(g, repo_name, pr_number, installation_token=installation_token)
         analysis = analyze_with_gemini(client, pr_details)
         suggestions = parse_code_suggestions(analysis)
-
-        repo = g.get_repo(repo_name)
-        pr = repo.get_pull(pr_number)
 
         if suggestions:
             apply_suggestions_to_pr(repo, pr, suggestions)

--- a/test/test_harperbot.py
+++ b/test/test_harperbot.py
@@ -630,69 +630,6 @@ class TestHarperBot(unittest.TestCase):
         mock_run_analysis.assert_not_called()
         mock_apply.assert_not_called()
 
-    @patch("harperbot.harperbot.post_notice_comment")
-    @patch("harperbot.harperbot.load_config")
-    @patch("harperbot.harperbot.setup_environment_webhook")
-    @patch("harperbot.harperbot.handle_apply_comment")
-    def test_handle_pr_comment_command_blocks_apply_when_authoring_disabled(
-        self, mock_apply, mock_setup_env, mock_load_config, mock_post_notice
-    ):
-        g = Mock()
-        repo = Mock()
-        pr = Mock()
-        g.get_repo.return_value = repo
-        repo.get_pull.return_value = pr
-        mock_setup_env.return_value = (g, "token", Mock())
-        mock_load_config.return_value = {"enable_authoring": False}
-
-        result = handle_pr_comment_command(123, "o/r", 1, "/apply", "alice")
-
-        self.assertEqual(result, ({"status": "forbidden"}, 403))
-        mock_post_notice.assert_called_once()
-        mock_apply.assert_not_called()
-
-    @patch("harperbot.harperbot.load_config")
-    @patch("harperbot.harperbot.setup_environment_webhook")
-    @patch("harperbot.harperbot.handle_apply_comment")
-    def test_handle_pr_comment_command_blocks_apply_without_write_permission(
-        self, mock_apply, mock_setup_env, mock_load_config
-    ):
-        g = Mock()
-        repo = Mock()
-        pr = Mock()
-        g.get_repo.return_value = repo
-        repo.get_pull.return_value = pr
-        repo.get_collaborator_permission.return_value = "read"
-        mock_setup_env.return_value = (g, "token", Mock())
-        mock_load_config.return_value = {"enable_authoring": True}
-
-        result = handle_pr_comment_command(123, "o/r", 1, "/apply", "alice")
-
-        self.assertEqual(result, ({"status": "forbidden"}, 403))
-        pr.create_issue_comment.assert_called_once()
-        mock_apply.assert_not_called()
-
-    @patch("harperbot.harperbot.load_config")
-    @patch("harperbot.harperbot.setup_environment_webhook")
-    @patch("harperbot.harperbot.handle_apply_comment")
-    def test_handle_pr_comment_command_blocks_apply_for_non_collaborator_lookup_failure(
-        self, mock_apply, mock_setup_env, mock_load_config
-    ):
-        g = Mock()
-        repo = Mock()
-        pr = Mock()
-        g.get_repo.return_value = repo
-        repo.get_pull.return_value = pr
-        repo.get_collaborator_permission.side_effect = GithubException(404, {"message": "Not Found"}, None)
-        mock_setup_env.return_value = (g, "token", Mock())
-        mock_load_config.return_value = {"enable_authoring": True}
-
-        result = handle_pr_comment_command(123, "o/r", 1, "/apply", "alice")
-
-        self.assertEqual(result, ({"status": "forbidden"}, 403))
-        pr.create_issue_comment.assert_called_once()
-        mock_apply.assert_not_called()
-
     @patch("harperbot.harperbot.jsonify", side_effect=lambda payload: payload)
     @patch("harperbot.harperbot.setup_environment_webhook")
     def test_handle_merge_command_rebase_405_returns_notice_not_500(self, mock_setup_env, _mock_jsonify):
@@ -720,6 +657,25 @@ class TestHarperBot(unittest.TestCase):
         pr.create_issue_comment.assert_called()
         body = pr.create_issue_comment.call_args[0][0]
         self.assertIn("Merge method not allowed", body)
+
+    @patch("harperbot.harperbot.jsonify", side_effect=lambda payload: payload)
+    @patch("harperbot.harperbot.setup_environment_webhook")
+    def test_handle_merge_command_blocks_non_collaborator_lookup_failure(self, mock_setup_env, _mock_jsonify):
+        from harperbot.harperbot import handle_merge_command
+
+        g = Mock()
+        repo = Mock()
+        pr = Mock()
+        g.get_repo.return_value = repo
+        repo.get_collaborator_permission.side_effect = GithubException(404, {"message": "Not Found"}, None)
+        repo.get_pull.return_value = pr
+        mock_setup_env.return_value = (g, "token", Mock())
+
+        payload, status = handle_merge_command(123, "o/r", 8, "merge", "external-user")
+
+        self.assertEqual(status, 403)
+        self.assertEqual(payload["status"], "forbidden")
+        pr.create_issue_comment.assert_called_once()
 
     @patch("harperbot.harperbot.post_notice_comment")
     @patch("harperbot.harperbot.setup_environment_webhook")

--- a/test/test_harperbot.py
+++ b/test/test_harperbot.py
@@ -630,6 +630,69 @@ class TestHarperBot(unittest.TestCase):
         mock_run_analysis.assert_not_called()
         mock_apply.assert_not_called()
 
+    @patch("harperbot.harperbot.post_notice_comment")
+    @patch("harperbot.harperbot.load_config")
+    @patch("harperbot.harperbot.setup_environment_webhook")
+    @patch("harperbot.harperbot.handle_apply_comment")
+    def test_handle_pr_comment_command_blocks_apply_when_authoring_disabled(
+        self, mock_apply, mock_setup_env, mock_load_config, mock_post_notice
+    ):
+        g = Mock()
+        repo = Mock()
+        pr = Mock()
+        g.get_repo.return_value = repo
+        repo.get_pull.return_value = pr
+        mock_setup_env.return_value = (g, "token", Mock())
+        mock_load_config.return_value = {"enable_authoring": False}
+
+        result = handle_pr_comment_command(123, "o/r", 1, "/apply", "alice")
+
+        self.assertEqual(result, ({"status": "forbidden"}, 403))
+        mock_post_notice.assert_called_once()
+        mock_apply.assert_not_called()
+
+    @patch("harperbot.harperbot.load_config")
+    @patch("harperbot.harperbot.setup_environment_webhook")
+    @patch("harperbot.harperbot.handle_apply_comment")
+    def test_handle_pr_comment_command_blocks_apply_without_write_permission(
+        self, mock_apply, mock_setup_env, mock_load_config
+    ):
+        g = Mock()
+        repo = Mock()
+        pr = Mock()
+        g.get_repo.return_value = repo
+        repo.get_pull.return_value = pr
+        repo.get_collaborator_permission.return_value = "read"
+        mock_setup_env.return_value = (g, "token", Mock())
+        mock_load_config.return_value = {"enable_authoring": True}
+
+        result = handle_pr_comment_command(123, "o/r", 1, "/apply", "alice")
+
+        self.assertEqual(result, ({"status": "forbidden"}, 403))
+        pr.create_issue_comment.assert_called_once()
+        mock_apply.assert_not_called()
+
+    @patch("harperbot.harperbot.load_config")
+    @patch("harperbot.harperbot.setup_environment_webhook")
+    @patch("harperbot.harperbot.handle_apply_comment")
+    def test_handle_pr_comment_command_blocks_apply_for_non_collaborator_lookup_failure(
+        self, mock_apply, mock_setup_env, mock_load_config
+    ):
+        g = Mock()
+        repo = Mock()
+        pr = Mock()
+        g.get_repo.return_value = repo
+        repo.get_pull.return_value = pr
+        repo.get_collaborator_permission.side_effect = GithubException(404, {"message": "Not Found"}, None)
+        mock_setup_env.return_value = (g, "token", Mock())
+        mock_load_config.return_value = {"enable_authoring": True}
+
+        result = handle_pr_comment_command(123, "o/r", 1, "/apply", "alice")
+
+        self.assertEqual(result, ({"status": "forbidden"}, 403))
+        pr.create_issue_comment.assert_called_once()
+        mock_apply.assert_not_called()
+
     @patch("harperbot.harperbot.jsonify", side_effect=lambda payload: payload)
     @patch("harperbot.harperbot.setup_environment_webhook")
     def test_handle_merge_command_rebase_405_returns_notice_not_500(self, mock_setup_env, _mock_jsonify):

--- a/test/test_harperbot_apply.py
+++ b/test/test_harperbot_apply.py
@@ -28,13 +28,12 @@ class TestHarperBotApply(unittest.TestCase):
         pr = Mock()
         g.get_repo.return_value = repo
         repo.get_pull.return_value = pr
-        repo.get_collaborator_permission.return_value = "write"
 
         fake_harperbot_mod.setup_environment_webhook = Mock(return_value=(g, "token", Mock()))
         fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": True})
         fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
         fake_harperbot_mod.get_commenter_permission = Mock(return_value="write")
-        fake_harperbot_mod.get_pr_details_webhook = Mock(return_value={"number": 1})
+        fake_harperbot_mod.build_pr_details_from_pr = Mock(return_value={"number": 1})
         fake_harperbot_mod.analyze_with_gemini = Mock(return_value="analysis text")
         fake_harperbot_mod.parse_code_suggestions = Mock(return_value=[])
         fake_harperbot_mod.apply_suggestions_to_pr = Mock()
@@ -60,13 +59,12 @@ class TestHarperBotApply(unittest.TestCase):
         pr = Mock()
         g.get_repo.return_value = repo
         repo.get_pull.return_value = pr
-        repo.get_collaborator_permission.return_value = "write"
 
         fake_harperbot_mod.setup_environment_webhook = Mock(return_value=(g, "token", Mock()))
         fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": True})
         fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
         fake_harperbot_mod.get_commenter_permission = Mock(return_value="write")
-        fake_harperbot_mod.get_pr_details_webhook = Mock(return_value={"number": 1})
+        fake_harperbot_mod.build_pr_details_from_pr = Mock(return_value={"number": 1})
         fake_harperbot_mod.analyze_with_gemini = Mock(return_value="analysis text")
         fake_harperbot_mod.parse_code_suggestions = Mock(return_value=[("a.txt", "1", "change")])
         fake_harperbot_mod.apply_suggestions_to_pr = Mock()
@@ -97,7 +95,7 @@ class TestHarperBotApply(unittest.TestCase):
         fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": False})
         fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
         fake_harperbot_mod.get_commenter_permission = Mock(return_value="write")
-        fake_harperbot_mod.get_pr_details_webhook = Mock()
+        fake_harperbot_mod.build_pr_details_from_pr = Mock()
         fake_harperbot_mod.analyze_with_gemini = Mock()
         fake_harperbot_mod.parse_code_suggestions = Mock()
         fake_harperbot_mod.apply_suggestions_to_pr = Mock()
@@ -125,13 +123,12 @@ class TestHarperBotApply(unittest.TestCase):
         pr = Mock()
         g.get_repo.return_value = repo
         repo.get_pull.return_value = pr
-        repo.get_collaborator_permission.return_value = "read"
 
         fake_harperbot_mod.setup_environment_webhook = Mock(return_value=(g, "token", Mock()))
         fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": True})
         fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
         fake_harperbot_mod.get_commenter_permission = Mock(return_value="read")
-        fake_harperbot_mod.get_pr_details_webhook = Mock()
+        fake_harperbot_mod.build_pr_details_from_pr = Mock()
         fake_harperbot_mod.analyze_with_gemini = Mock()
         fake_harperbot_mod.parse_code_suggestions = Mock()
         fake_harperbot_mod.apply_suggestions_to_pr = Mock()
@@ -164,7 +161,7 @@ class TestHarperBotApply(unittest.TestCase):
         fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": True})
         fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
         fake_harperbot_mod.get_commenter_permission = Mock(return_value=None)
-        fake_harperbot_mod.get_pr_details_webhook = Mock()
+        fake_harperbot_mod.build_pr_details_from_pr = Mock()
         fake_harperbot_mod.analyze_with_gemini = Mock()
         fake_harperbot_mod.parse_code_suggestions = Mock()
         fake_harperbot_mod.apply_suggestions_to_pr = Mock()

--- a/test/test_harperbot_apply.py
+++ b/test/test_harperbot_apply.py
@@ -28,8 +28,12 @@ class TestHarperBotApply(unittest.TestCase):
         pr = Mock()
         g.get_repo.return_value = repo
         repo.get_pull.return_value = pr
+        repo.get_collaborator_permission.return_value = "write"
 
         fake_harperbot_mod.setup_environment_webhook = Mock(return_value=(g, "token", Mock()))
+        fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": True})
+        fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
+        fake_harperbot_mod.get_commenter_permission = Mock(return_value="write")
         fake_harperbot_mod.get_pr_details_webhook = Mock(return_value={"number": 1})
         fake_harperbot_mod.analyze_with_gemini = Mock(return_value="analysis text")
         fake_harperbot_mod.parse_code_suggestions = Mock(return_value=[])
@@ -40,7 +44,7 @@ class TestHarperBotApply(unittest.TestCase):
             patch.object(harperbot_apply, "jsonify", lambda obj: obj),
             patch.dict(sys.modules, {"harperbot.harperbot": fake_harperbot_mod}),
         ):
-            result = harperbot_apply.handle_apply_comment(123, "o/r", 1)
+            result = harperbot_apply.handle_apply_comment(123, "o/r", 1, commenter_login="alice")
 
         pr.create_issue_comment.assert_called_once_with("No code suggestions found to apply.")
         fake_harperbot_mod.apply_suggestions_to_pr.assert_not_called()
@@ -56,8 +60,12 @@ class TestHarperBotApply(unittest.TestCase):
         pr = Mock()
         g.get_repo.return_value = repo
         repo.get_pull.return_value = pr
+        repo.get_collaborator_permission.return_value = "write"
 
         fake_harperbot_mod.setup_environment_webhook = Mock(return_value=(g, "token", Mock()))
+        fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": True})
+        fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
+        fake_harperbot_mod.get_commenter_permission = Mock(return_value="write")
         fake_harperbot_mod.get_pr_details_webhook = Mock(return_value={"number": 1})
         fake_harperbot_mod.analyze_with_gemini = Mock(return_value="analysis text")
         fake_harperbot_mod.parse_code_suggestions = Mock(return_value=[("a.txt", "1", "change")])
@@ -68,8 +76,108 @@ class TestHarperBotApply(unittest.TestCase):
             patch.object(harperbot_apply, "jsonify", lambda obj: obj),
             patch.dict(sys.modules, {"harperbot.harperbot": fake_harperbot_mod}),
         ):
-            result = harperbot_apply.handle_apply_comment(123, "o/r", 1)
+            result = harperbot_apply.handle_apply_comment(123, "o/r", 1, commenter_login="alice")
 
         fake_harperbot_mod.apply_suggestions_to_pr.assert_called_once_with(repo, pr, [("a.txt", "1", "change")])
         pr.create_issue_comment.assert_called_once_with("Applied code suggestions from HarperBot analysis.")
         self.assertEqual(result, {"status": "applied"})
+
+    def test_handle_apply_comment_rejects_when_authoring_disabled(self):
+        from harperbot import harperbot_apply
+
+        fake_harperbot_mod = types.SimpleNamespace()
+
+        g = Mock()
+        repo = Mock()
+        pr = Mock()
+        g.get_repo.return_value = repo
+        repo.get_pull.return_value = pr
+
+        fake_harperbot_mod.setup_environment_webhook = Mock(return_value=(g, "token", Mock()))
+        fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": False})
+        fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
+        fake_harperbot_mod.get_commenter_permission = Mock(return_value="write")
+        fake_harperbot_mod.get_pr_details_webhook = Mock()
+        fake_harperbot_mod.analyze_with_gemini = Mock()
+        fake_harperbot_mod.parse_code_suggestions = Mock()
+        fake_harperbot_mod.apply_suggestions_to_pr = Mock()
+
+        with (
+            patch.object(harperbot_apply, "flask_available", True),
+            patch.object(harperbot_apply, "jsonify", lambda obj: obj),
+            patch.dict(sys.modules, {"harperbot.harperbot": fake_harperbot_mod}),
+        ):
+            payload, status = harperbot_apply.handle_apply_comment(123, "o/r", 1, commenter_login="alice")
+
+        self.assertEqual(status, 403)
+        self.assertEqual(payload, {"status": "forbidden"})
+        pr.create_issue_comment.assert_called_once()
+        fake_harperbot_mod.analyze_with_gemini.assert_not_called()
+        fake_harperbot_mod.apply_suggestions_to_pr.assert_not_called()
+
+    def test_handle_apply_comment_rejects_without_write_permission(self):
+        from harperbot import harperbot_apply
+
+        fake_harperbot_mod = types.SimpleNamespace()
+
+        g = Mock()
+        repo = Mock()
+        pr = Mock()
+        g.get_repo.return_value = repo
+        repo.get_pull.return_value = pr
+        repo.get_collaborator_permission.return_value = "read"
+
+        fake_harperbot_mod.setup_environment_webhook = Mock(return_value=(g, "token", Mock()))
+        fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": True})
+        fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
+        fake_harperbot_mod.get_commenter_permission = Mock(return_value="read")
+        fake_harperbot_mod.get_pr_details_webhook = Mock()
+        fake_harperbot_mod.analyze_with_gemini = Mock()
+        fake_harperbot_mod.parse_code_suggestions = Mock()
+        fake_harperbot_mod.apply_suggestions_to_pr = Mock()
+
+        with (
+            patch.object(harperbot_apply, "flask_available", True),
+            patch.object(harperbot_apply, "jsonify", lambda obj: obj),
+            patch.dict(sys.modules, {"harperbot.harperbot": fake_harperbot_mod}),
+        ):
+            payload, status = harperbot_apply.handle_apply_comment(123, "o/r", 1, commenter_login="alice")
+
+        self.assertEqual(status, 403)
+        self.assertEqual(payload, {"status": "forbidden"})
+        pr.create_issue_comment.assert_called_once()
+        fake_harperbot_mod.analyze_with_gemini.assert_not_called()
+        fake_harperbot_mod.apply_suggestions_to_pr.assert_not_called()
+
+    def test_handle_apply_comment_rejects_non_collaborator_lookup_failure(self):
+        from harperbot import harperbot_apply
+
+        fake_harperbot_mod = types.SimpleNamespace()
+
+        g = Mock()
+        repo = Mock()
+        pr = Mock()
+        g.get_repo.return_value = repo
+        repo.get_pull.return_value = pr
+
+        fake_harperbot_mod.setup_environment_webhook = Mock(return_value=(g, "token", Mock()))
+        fake_harperbot_mod.load_config = Mock(return_value={"enable_authoring": True})
+        fake_harperbot_mod.format_notice = Mock(side_effect=lambda title, details: f"{title}: {details}")
+        fake_harperbot_mod.get_commenter_permission = Mock(return_value=None)
+        fake_harperbot_mod.get_pr_details_webhook = Mock()
+        fake_harperbot_mod.analyze_with_gemini = Mock()
+        fake_harperbot_mod.parse_code_suggestions = Mock()
+        fake_harperbot_mod.apply_suggestions_to_pr = Mock()
+
+        with (
+            patch.object(harperbot_apply, "flask_available", True),
+            patch.object(harperbot_apply, "jsonify", lambda obj: obj),
+            patch.dict(sys.modules, {"harperbot.harperbot": fake_harperbot_mod}),
+        ):
+            payload, status = harperbot_apply.handle_apply_comment(123, "o/r", 1, commenter_login="external-user")
+
+        self.assertEqual(status, 403)
+        self.assertEqual(payload, {"status": "forbidden"})
+        pr.create_issue_comment.assert_called_once()
+        fake_harperbot_mod.analyze_with_gemini.assert_not_called()
+        fake_harperbot_mod.apply_suggestions_to_pr.assert_not_called()

--- a/website/app.html
+++ b/website/app.html
@@ -43,7 +43,7 @@
 
       <section>
         <h2>Auto-Commit</h2>
-        <p>Actionable code suggestions that can be applied directly to your branch with a click.</p>
+        <p>Actionable code suggestions can be applied back to a PR branch when authoring is enabled and the person invoking the command has write or admin access.</p>
       </section>
 
       <section>

--- a/website/experience.html
+++ b/website/experience.html
@@ -77,6 +77,7 @@
           <li><span></span>Always create a PR review entry, even when there are no inline suggestions</li>
           <li><span></span>Optional range comments: enable "comment on lines +X to +Y" for block feedback</li>
           <li><span></span><code>/apply</code> needs robust parsing (simplified diff blocks + deletions)</li>
+          <li><span></span><code>/apply</code> is intentionally permission-gated: authoring must be enabled and the commenter must have write/admin access</li>
           <li><span></span>Per-PR controls: <code>/pause</code>, <code>/resume</code>, <code>/status</code></li>
           <li><span></span>Quota handling: temporary cooldown on auto-runs with manual override via <code>/analyze</code></li>
         </ul>
@@ -88,7 +89,7 @@
 /apply
 /pause   /resume   /status
 /merge   /squash   /rebase</code></pre>
-        <p class="subtext">Commands work from Conversation comments, and (when enabled) inline file comments.</p>
+        <p class="subtext">Commands work from Conversation comments, and (when enabled) inline file comments. Write-capable commands still depend on repository permissions and feature flags.</p>
       </section>
 
       <section>

--- a/website/layout.js
+++ b/website/layout.js
@@ -38,7 +38,6 @@ class FaviconManager {
 
 class ResponsiveLayout {
   constructor() {
-    console.log('ResponsiveLayout: Initializing');
     this.init();
     window.addEventListener('resize', () => this.handleResize());
     window.addEventListener('orientationchange', () => this.handleOrientationChange());
@@ -118,13 +117,11 @@ class ResponsiveLayout {
   }
 
   handleResize() {
-    console.log('ResponsiveLayout: Window resized');
     this.setViewportHeight();
     this.adjustContentForScreen();
   }
 
   handleOrientationChange() {
-    console.log('ResponsiveLayout: Orientation changed');
     setTimeout(() => {
       this.setViewportHeight();
       this.adjustContentForScreen();
@@ -134,7 +131,6 @@ class ResponsiveLayout {
 
 class LayoutManager {
   constructor() {
-    console.log('LayoutManager: Initializing');
     this.faviconManager = new FaviconManager();
     this.responsiveLayout = null;
     this.init();
@@ -149,7 +145,6 @@ class LayoutManager {
   }
 
   setup() {
-    console.log('LayoutManager: Setting up layout');
     this.responsiveLayout = new ResponsiveLayout();
     this.setupGlobalStyles();
   }

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -38,8 +38,9 @@
         <h2>What we collect</h2>
         <ul>
           <li><strong>Personal information:</strong> Name and email when you contact us.</li>
-          <li><strong>Usage data:</strong> Anonymous usage analytics to improve our services.</li>
-          <li><strong>Cookies:</strong> Minimal cookies for site functionality and analytics.</li>
+          <li><strong>Basic request data:</strong> Standard browser and server metadata needed to load and serve the site.</li>
+          <li><strong>Direct contact details:</strong> Information you choose to send when you email us.</li>
+          <li><strong>No first-party analytics cookies in the current site code:</strong> The static pages in this repository do not currently ship a cookie banner or bundled analytics tracker.</li>
         </ul>
       </section>
 
@@ -48,7 +49,8 @@
         <p>We use your information solely to:</p>
         <ul>
           <li>Respond to your inquiries and provide support.</li>
-          <li>Improve our website and services based on aggregate analytics.</li>
+          <li>Operate and secure the site.</li>
+          <li>Improve the project and documentation based on direct feedback.</li>
           <li>Comply with legal obligations when required.</li>
         </ul>
       </section>
@@ -60,7 +62,7 @@
 
       <section>
         <h2>Third-party services</h2>
-        <p>We may use third-party services (e.g., analytics) that collect anonymized data. These services comply with privacy standards and do not share your personal information.</p>
+        <p>This website links to third-party services such as GitHub and RubyGems. If you choose to visit those services, their privacy policies apply there. The static site code in this repository does not currently embed a dedicated analytics or advertising script.</p>
       </section>
 
       <section>
@@ -69,7 +71,7 @@
         <ul>
           <li>Request access to your personal data.</li>
           <li>Request correction or deletion of your data.</li>
-          <li>Opt-out of analytics cookies via browser settings.</li>
+          <li>Ask what contact information we retain if you contacted us directly.</li>
         </ul>
       </section>
 

--- a/website/support.html
+++ b/website/support.html
@@ -53,6 +53,7 @@
           <li><span></span>Optional multi-line inline review comments ("comment on lines ...")</li>
           <li><span></span>Common log patterns and how to interpret them</li>
         </ul>
+        <p class="subtext"><code>/apply</code> is a privileged command. It requires authoring to be enabled and the commenter to have write or admin access on the repository.</p>
       </section>
 
       <section>
@@ -63,6 +64,7 @@ Pull requests: read &amp; write
 Issues: read &amp; write
 Code/Contents: read &amp; write</code></pre>
         <p class="subtext">Everything else: No access (Actions/Checks/Secrets/Administration/etc.).</p>
+        <p class="subtext">Comment-level access is not enough for write operations. A non-collaborator may be able to comment on a PR but should still be denied for <code>/apply</code> and merge commands.</p>
       </section>
 
       <section>
@@ -112,6 +114,11 @@ Pull request review comment</code></pre>
               <td data-label="Resolution">Support simplified diff blocks + deletion operations; apply deletes safely</td>
             </tr>
             <tr>
+              <td data-label="Symptom"><code>/apply</code> should not run for external contributors or when authoring is disabled</td>
+              <td data-label="Root cause">Write-capable command needed explicit config and permission gating</td>
+              <td data-label="Resolution">Require <code>enable_authoring: true</code> and write/admin access; treat collaborator lookup failures as deny</td>
+            </tr>
+            <tr>
               <td data-label="Symptom">Wanted "comment on lines +X to +Y" style inline reviews</td>
               <td data-label="Root cause">Inline reviews were posted as single-line comments only</td>
               <td data-label="Resolution">Added optional range comments (multi-line) gated by <code>HARPERBOT_ENABLE_RANGE_COMMENTS</code></td>
@@ -137,7 +144,7 @@ Pull request review comment</code></pre>
             <li><span></span>Create a PR with a small code change</li>
             <li><span></span>Comment <code>/analyze</code> in Conversation (and optionally as an inline file comment)</li>
             <li><span></span>Verify a PR review appears (“View reviewed changes”)</li>
-            <li><span></span>Comment <code>/apply</code> and confirm a bot-authored commit lands on the PR branch</li>
+            <li><span></span>If authoring is enabled and the commenter has write/admin access, comment <code>/apply</code> and confirm a bot-authored commit lands on the PR branch</li>
             <li><span></span>Optionally test merges: <code>/merge</code>, <code>/squash</code>, <code>/rebase</code></li>
             <li><span></span>Pause auto runs: <code>/pause</code>; re-enable: <code>/resume</code></li>
           </ul>


### PR DESCRIPTION
Closes #162

## Important
HarperBot works across repositories where the GitHub App is installed, but write-capable commands are not universally available.

The apply command now requires both of the following:
- authoring must be enabled in config
- the commenter must have write or admin access on the repository

Merge commands also rely on repository-level write or admin permission, and both apply and merge now treat collaborator lookup failures as an authorization deny instead of a server error.

## Summary
- secure the apply command behind explicit authoring and repository permission checks
- treat collaborator permission lookup failures as unprivileged for both apply and merge flows
- keep apply authorization in a single enforcement path instead of duplicating it in the command dispatcher
- avoid duplicate repository and pull request fetching in the apply path by reusing the existing PR object
- consolidate duplicate apply authorization test coverage into the dedicated apply test file
- update website copy so the public docs match the current authorization model and privacy wording

## Why this change matters
Before this patch, HarperBot behavior was too easy to over-assume. Installation alone did not guarantee that every slash command would work for every user in every repository context.

This PR makes the write boundary explicit in code and in the website copy. It also prevents permission lookup edge cases from turning authorization failures into internal server errors.

## Testing
- python3 -m pytest test/test_harperbot_apply.py
- python3 -m pytest test/test_harperbot.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `/apply` now enforces permission checks: requires authoring enabled and write/admin repository access; collaborator lookup failures are treated as denial and result in a forbidden response.

* **Documentation**
  * Clarified that `/apply` is privileged and gated by feature flags and collaborator permissions.
  * Updated privacy policy wording about data collection and lack of bundled analytics.

* **Tests**
  * Added and updated tests covering permission failures and gated `/apply` behavior.

* **Chores**
  * Removed debug logging from layout code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->