### PR TITLE
chore: pin harperbot python deps

### DIFF
--- a/.github/workflows/harperbot.yml
+++ b/.github/workflows/harperbot.yml
@@ -109,8 +109,8 @@ jobs:
     # Install Python dependencies required for HarperBot
       - name: Install dependencies
         run: |
-          # Install Python dependencies
-          pip install --no-cache-dir PyGithub python-dotenv PyYAML google-genai
+          # Install pinned HarperBot dependencies (direct + transitive) for reproducible runs
+          pip install --no-cache-dir -r harperbot/requirements.lock
 
           # Verify installations
           python --version

--- a/harperbot/requirements.lock
+++ b/harperbot/requirements.lock
@@ -1,0 +1,45 @@
+# Pinned HarperBot Python dependencies (direct + transitive).
+#
+# Update process:
+# - Use a clean venv, install the HarperBot deps, then `pip freeze` into this file.
+# - Keep the workflow installing from this lock so CI runs are reproducible.
+#
+# Last refreshed: 2026-04-13
+annotated-types==0.7.0
+anyio==4.13.0
+blinker==1.9.0
+certifi==2026.2.25
+cffi==2.0.0
+charset-normalizer==3.4.7
+click==8.3.2
+cryptography==46.0.7
+distro==1.9.0
+exceptiongroup==1.3.1
+Flask==3.1.3
+google-auth==2.49.2
+google-genai==1.72.0
+h11==0.16.0
+httpcore==1.0.9
+httpx==0.28.1
+idna==3.11
+itsdangerous==2.2.0
+Jinja2==3.1.6
+MarkupSafe==3.0.3
+pyasn1==0.6.3
+pyasn1_modules==0.4.2
+pycparser==3.0
+pydantic==2.12.5
+pydantic_core==2.41.5
+PyGithub==2.9.0
+PyJWT==2.12.1
+PyNaCl==1.6.2
+python-dotenv==1.2.2
+PyYAML==6.0.3
+requests==2.33.1
+sniffio==1.3.1
+tenacity==9.1.4
+typing-inspection==0.4.2
+typing_extensions==4.15.0
+urllib3==2.6.3
+websockets==16.0
+Werkzeug==3.1.8


### PR DESCRIPTION
This PR pins HarperBot's Python dependencies so the GitHub Action doesn't float to new versions unexpectedly.

Changes:
- Add `harperbot/requirements.lock` (pip-freeze style lock, direct + transitive deps).
- Update `.github/workflows/harperbot.yml` to `pip install -r harperbot/requirements.lock`.

Notes:
- The lockfile was generated from a clean venv and captures versions as of 2026-04-13.
- This improves reproducibility and reduces supply-chain surprise during CI runs.
